### PR TITLE
Build improvements

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+# .coveragerc to control coverage.py
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma:
+    pragma: no cover
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ after_success:
   - pyflakes scripts/*.py
 
 matrix:
+  fast_finish: true
   allow_failures:
     - python: 2.6
     - python: 3.2


### PR DESCRIPTION
- Fast finish: mark a build as passed or failed sooner, without having to wait for non-important builds.
- Don't cover the `__main__` section of the script.
