### PR TITLE
Whitelist all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,10 @@ python:
 
 # whitelist
 # gh-pages is otherwise ignored by Travis CI
+# Use a regex to whitelist gh-pages and all branches
 branches:
   only:
-    - gh-pages
+    - /.*/
 
 install:
   - pip install -r requirements.txt


### PR DESCRIPTION
So Travis CI ignores gh-pages by default which is why it was whitelisted:

```
branches:
  only:
    - gh-pages
```

But it would be useful to build other branches too. So we can use a regex whitelist to match all branches:

```
branches:
  only:
    - /.*/
```

Yes, tell Travis to build only anything.

Docs: http://docs.travis-ci.com/user/build-configuration/#Using-regular-expressions
