### PR TITLE
Check for missing metadata files

### DIFF
--- a/scripts/missing.py
+++ b/scripts/missing.py
@@ -6,6 +6,16 @@ Find missing images.
 import os
 import gpo_member_photos
 
+
+def file_exists(filename):
+    if not os.path.exists(filename):
+        print "---"
+        print "Not found:", filename
+        print l['name']
+        return False
+    return True
+
+
 if __name__ == "__main__":
     # clone or update legislator YAML
     gpo_member_photos.download_legislator_data()
@@ -15,9 +25,9 @@ if __name__ == "__main__":
     for l in legislators:
         bioguide = l['id']['bioguide']
         filename = os.path.join("congress", "original", bioguide + ".jpg")
-        if not os.path.exists(filename):
-            print "---"
-            print "Not found:", filename
-            print l['name']
+        if file_exists(filename):
+            # Only check for yaml if jpg exists
+            filename = os.path.join("congress", "metadata", bioguide + ".yaml")
+            file_exists(filename)
 
 # End of file


### PR DESCRIPTION
As we're adding a load of new images, add a check for missing metadata yaml files too (as I did forget to add some earlier).

Don't bother reporting a yaml is missing if its jpeg is also missing.
