### PR TITLE
Python 2.6 and 3.x fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ branches:
 install:
   - pip install -r requirements.txt
   - pip install coveralls
+  - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then travis_retry pip install unittest2; fi
 
 script:
   - coverage run --source scripts/gpo_member_photos.py test/test_gpo_member_photos.py

--- a/scripts/gpo_member_photos.py
+++ b/scripts/gpo_member_photos.py
@@ -10,14 +10,23 @@ import datetime
 import os
 import re
 import sys
-import time
-import urlparse
 import json
+import time
+try:
+    # Python 3
+    from urllib.error import HTTPError
+    from urllib.parse import parse_qs
+    from urllib.parse import urlparse
+except ImportError:
+    # Python 2
+    from urllib2 import HTTPError
+    from urlparse import parse_qs
+    from urlparse import urlparse
 
 # pip install -r requirements.txt
 import mechanize
 import yaml
-from urllib2 import HTTPError
+
 
 
 # Windows cmd.exe cannot do Unicode so encode first
@@ -173,8 +182,8 @@ def download_legislator_data():
 
 
 def bioguide_id_from_url(url):
-    bioguide_id = urlparse.parse_qs(
-        urlparse.urlparse(url).query)['index'][0].strip("/")
+    bioguide_id = parse_qs(
+        urlparse(url).query)['index'][0].strip("/")
     bioguide_id = str(bioguide_id.strip(u"\u200E"))
     bioguide_id = bioguide_id.capitalize()
     return bioguide_id

--- a/scripts/gpo_member_photos.py
+++ b/scripts/gpo_member_photos.py
@@ -4,6 +4,7 @@
 Scrape http://www.memberguide.gpoaccess.gov and
 save members' photos named after their Bioguide IDs.
 """
+from __future__ import print_function
 import argparse
 import datetime
 import os
@@ -33,14 +34,14 @@ def pause(last, delay):
 
     if delta < delay:
         sleep = delay - delta
-        print "Sleep for", int(sleep), "seconds"
+        print("Sleep for", int(sleep), "seconds")
         time.sleep(sleep)
     return datetime.datetime.now()
 
 
 def get_front_page(br, congress_number, delay):
 
-    print "Submit congress session number:", congress_number
+    print("Submit congress session number:", congress_number)
 
     # the JSON used to populate the memberguide site
     url = r'http://www.memberguide.gpoaccess.gov/Congressional.svc/GetMembers/{0}'.format(congress_number)
@@ -77,7 +78,7 @@ def get_front_page(br, congress_number, delay):
                 # links will be a list of dictionaries where the "url" is a
                 # link to the image and "name" is the rep's name
 
-    print "Links:", len(links)
+    print("Links:", len(links))
     return links
 
 
@@ -158,13 +159,13 @@ def reverse_names(text):
 def download_legislator_data():
     # clone it if it's not out
     if not os.path.exists("congress-legislators"):
-        print "Cloning the congress-legislators repo..."
+        print("Cloning the congress-legislators repo...")
         os.system("git clone -q --depth 1 "
                   "https://github.com/unitedstates/congress-legislators "
                   "congress-legislators")
 
     # Update the repo so we have the latest.
-    print "Updating the congress-legislators repo..."
+    print("Updating the congress-legislators repo...")
     # these two == git pull, but git pull ignores -q on the merge part
     # so is less quiet
     os.system("cd congress-legislators; git fetch -pq; "
@@ -206,7 +207,7 @@ def save_metadata(bioguide_id):
 
 def download_photos(br, member_links, outdir, cachedir, delay):
     last_request_time = None
-    print "Found a total of", len(member_links), "member links"
+    print("Found a total of", len(member_links), "member links")
     if not os.path.exists(outdir):
         os.makedirs(outdir)
     if not os.path.exists(cachedir):
@@ -216,14 +217,14 @@ def download_photos(br, member_links, outdir, cachedir, delay):
     legislators = load_yaml("congress-legislators/legislators-current.yaml")
 
     for i, member_link in enumerate(member_links):
-        print "---"
+        print("---")
         print("Processing member", i+1, "of", len(member_links), ":",
               member_link["name"].encode('latin-1'))
         bioguide_id = None
 
         cachefile = os.path.join(
             cachedir, member_link["img_url"].replace("/", "_") + ".html")
-        # print os.path.isfile(cachefile)
+        # print(os.path.isfile(cachefile))
 
         html = ""
 
@@ -240,8 +241,8 @@ def download_photos(br, member_links, outdir, cachedir, delay):
             except HTTPError:
                 pass
             else:
-                print member_link["img_url"]
-                # print response.read()
+                print(member_link["img_url"])
+                # print(response.read())
                 html = response.read()
                 if len(html) > 0:
                     # Save page to cache
@@ -254,25 +255,25 @@ def download_photos(br, member_links, outdir, cachedir, delay):
             bioguide_id = resolve(legislators, member_link['name'])
 
             if not bioguide_id:
-                print "Bioguide ID not resolved"
+                print("Bioguide ID not resolved")
                 todo_resolve.append(member_link)
 
         # Download image
         if bioguide_id:
-            print "Bioguide ID:", bioguide_id
+            print("Bioguide ID:", bioguide_id)
 
             # TODO: Fine for now as only one image on the page
 
             filename = os.path.join(outdir, bioguide_id + ".jpg")
             if os.path.isfile(filename):
-                print "Image already exists:", filename
+                print("Image already exists:", filename)
             elif not args.test:
-                print "Saving image to", filename
+                print("Saving image to", filename)
                 last_request_time = pause(last_request_time, delay)
                 try:
                     data = br.open(member_link['img_url']).read()
                 except HTTPError:
-                    print "Image not available"
+                    print("Image not available")
                 else:
                     save = open(filename, 'wb')
                     save.write(data)
@@ -285,10 +286,10 @@ def download_photos(br, member_links, outdir, cachedir, delay):
     # TODO: For each entry remaining here, check if they've since left
     # Congress. If not, either need to add a resolving case above, or fix the
     # GPO/YAML data.
-    print "---"
-    print "Didn't resolve Bioguide IDs:", len(todo_resolve)
+    print("---")
+    print("Didn't resolve Bioguide IDs:", len(todo_resolve))
     for member_link in todo_resolve:
-        print member_link['img_url'], member_link['name']
+        print(member_link['img_url'], member_link['name'])
 
 
 def resize_photos():

--- a/scripts/missing.py
+++ b/scripts/missing.py
@@ -3,15 +3,16 @@
 """
 Find missing images.
 """
+from __future__ import print_function
 import os
 import gpo_member_photos
 
 
 def file_exists(filename):
     if not os.path.exists(filename):
-        print "---"
-        print "Not found:", filename
-        print l['name']
+        print("---")
+        print("Not found:", filename)
+        print(l['name'])
         return False
     return True
 

--- a/test/test_gpo_member_photos.py
+++ b/test/test_gpo_member_photos.py
@@ -6,10 +6,14 @@ Run from root `images` dir:
 `python test/test_gpo_member_photos.py`
 """
 import sys
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 sys.path.insert(0, 'scripts')
 import gpo_member_photos
+
 
 class TestSequenceFunctions(unittest.TestCase):
 
@@ -17,43 +21,47 @@ class TestSequenceFunctions(unittest.TestCase):
 
     def setUp(self):
         if self.yaml_data is None:
-            self.__class__.yaml_data = gpo_member_photos.load_yaml("test/legislators-test.yaml")
+            self.__class__.yaml_data = gpo_member_photos.load_yaml(
+                "test/legislators-test.yaml")
             self.assertTrue(len(self.yaml_data))
-
 
     # Test bioguide_id_from_url()
 
     def test_bioguide_id_from_url__last_char_not_slash(self):
         """ Test last char is not / """
-        input = "http://bioguide.congress.gov/scripts/biodisplay.pl?index=S001177/"
+        input = ("http://bioguide.congress.gov/scripts/biodisplay.pl"
+                 "?index=S001177/")
         output = gpo_member_photos.bioguide_id_from_url(input)
         self.assertNotEqual(output[-1], "/")
 
     def test_bioguide_id_from_url__last_char_not_slash2(self):
         """ Test last char is not / """
-        input = "http://bioguide.congress.gov/scripts/biodisplay.pl?index=S001177"
+        input = ("http://bioguide.congress.gov/scripts/biodisplay.pl"
+                 "?index=S001177")
         output = gpo_member_photos.bioguide_id_from_url(input)
         self.assertNotEqual(output[-1], "/")
 
     def test_bioguide_id_from_url__is_string(self):
         """ Test output is string """
-        input = "http://bioguide.congress.gov/scripts/biodisplay.pl?index=S001177/"
+        input = ("http://bioguide.congress.gov/scripts/biodisplay.pl"
+                 "?index=S001177/")
         output = gpo_member_photos.bioguide_id_from_url(input)
         self.assertIsInstance(output, str)
 
     def test_bioguide_id_from_url__uppercase(self):
         """ Test output is string """
-        input = "http://bioguide.congress.gov/scripts/biodisplay.pl?index=e000288/"
+        input = ("http://bioguide.congress.gov/scripts/biodisplay.pl"
+                 "?index=e000288/")
         output = gpo_member_photos.bioguide_id_from_url(input)
         self.assertEqual(output[0], "E")
 
     def test_bioguide_id_from_url_with_ltr_mark(self):
         """ For some reason, some new URL links end with
         Unicode Character 'LEFT-TO-RIGHT MARK' (U+200E) """
-        input = "http://bioguide.congress.gov/scripts/biodisplay.pl?index=g000386" + u"\u200E" + "/"
+        input = ("http://bioguide.congress.gov/scripts/biodisplay.pl"
+                 "?index=g000386" + u"\u200E" + "/")
         output = gpo_member_photos.bioguide_id_from_url(input)
         self.assertEqual(output, "G000386")
-
 
     # Test bioguide_id_valid()
 
@@ -87,7 +95,6 @@ class TestSequenceFunctions(unittest.TestCase):
         output = gpo_member_photos.bioguide_id_valid(input)
         self.assertFalse(output)
 
-
     # Test remove_from_yaml()
 
     def test_remove_from_yaml__success(self):
@@ -95,7 +102,8 @@ class TestSequenceFunctions(unittest.TestCase):
         bioguide_id = "C000127"
         length_before = len(self.yaml_data)
 
-        self.yaml_data = gpo_member_photos.remove_from_yaml(self.yaml_data, bioguide_id)
+        self.yaml_data = gpo_member_photos.remove_from_yaml(self.yaml_data,
+                                                            bioguide_id)
         self.assertTrue(length_before > len(self.yaml_data))
         self.assertEqual(len(self.yaml_data) + 1, length_before)
 
@@ -103,9 +111,9 @@ class TestSequenceFunctions(unittest.TestCase):
         """ Test same size """
         bioguide_id = "NOT_THERE"
         length_before = len(self.yaml_data)
-        self.yaml_data = gpo_member_photos.remove_from_yaml(self.yaml_data, bioguide_id)
+        self.yaml_data = gpo_member_photos.remove_from_yaml(self.yaml_data,
+                                                            bioguide_id)
         self.assertEqual(len(self.yaml_data), length_before)
-
 
     # Test reverse_names()
 
@@ -114,7 +122,6 @@ class TestSequenceFunctions(unittest.TestCase):
         text = "Hagan, Kay R."
         output = gpo_member_photos.reverse_names(text)
         self.assertEqual(output, "Kay R. Hagan")
-
 
     # Test resolve()
 
@@ -141,12 +148,6 @@ class TestSequenceFunctions(unittest.TestCase):
         text = u"Velázquez, Nydia M."
         output = gpo_member_photos.resolve(self.yaml_data, text)
         self.assertEqual(output, "V000081")
-
-    def test_resolve__initial_dot_from_middle(self):
-        """ Test resolve """
-        text = "Kirk, Mark S."
-        output = gpo_member_photos.resolve(self.yaml_data, text)
-        self.assertEqual(output, "K000360")
 
     def test_resolve__initial_dot_from_middle(self):
         """ Test resolve """
@@ -204,8 +205,8 @@ class TestSequenceFunctions(unittest.TestCase):
 
     def test_resolve__empty_text(self):
         """ Test resolve special case """
-        text = "Gutierrez, Luis"
-        output = gpo_member_photos.resolve(self.yaml_data, "")
+        text = ""
+        output = gpo_member_photos.resolve(self.yaml_data, text)
         self.assertEqual(output, None)
 
     def test_resolve__none(self):


### PR DESCRIPTION
- Update so tests pass on Python 2.6. This was just a matter of using `unittest2` for Py 2.6.
- Updates to improve Python 3.x compatibility. This means using Python 3-style prints and importing the right urllib/urlparse libraries. It still won't run on Python 3 because Mechanize doesn't support Python 3, but if we find a replacement, we're a bit closer.
- Remove a duplicate test: `test_resolve__initial_dot_from_middle()`
- Flake8 fixes.
