### PR TITLE
Fix test_resolve__none()

### DIFF
--- a/scripts/gpo_member_photos.py
+++ b/scripts/gpo_member_photos.py
@@ -28,7 +28,6 @@ import mechanize
 import yaml
 
 
-
 # Windows cmd.exe cannot do Unicode so encode first
 def print_it(text):
     print(text.encode('utf-8'))

--- a/scripts/gpo_member_photos.py
+++ b/scripts/gpo_member_photos.py
@@ -111,6 +111,9 @@ def get_value(item, key1, key2):
 
 
 def resolve(data, text):
+    if text is None:
+        return None
+
     if isinstance(text, str):
         text = text.decode('utf-8')
 

--- a/test/test_gpo_member_photos.py
+++ b/test/test_gpo_member_photos.py
@@ -212,7 +212,7 @@ class TestSequenceFunctions(unittest.TestCase):
     def test_resolve__none(self):
         """ Test resolve special case """
         text = None
-        output = gpo_member_photos.resolve(self.yaml_data, "")
+        output = gpo_member_photos.resolve(self.yaml_data, text)
         self.assertEqual(output, None)
 
 if __name__ == '__main__':

--- a/test/test_gpo_member_photos.py
+++ b/test/test_gpo_member_photos.py
@@ -65,25 +65,25 @@ class TestSequenceFunctions(unittest.TestCase):
 
     # Test bioguide_id_valid()
 
-    def test_bioguide_id_valid__None_returns_False(self):
+    def test_bioguide_id_valid__none_returns_false(self):
         """ Test with None """
         input = None
         output = gpo_member_photos.bioguide_id_valid(input)
         self.assertFalse(output)
 
-    def test_bioguide_id_valid__returns_True(self):
+    def test_bioguide_id_valid__returns_true(self):
         """ Test with a valid ID """
         input = "K000362"
         output = gpo_member_photos.bioguide_id_valid(input)
         self.assertTrue(output)
 
-    def test_bioguide_id_valid__returns_False(self):
+    def test_bioguide_id_valid__returns_false(self):
         """ Test with an invalid ID """
         input = "aK000362z"
         output = gpo_member_photos.bioguide_id_valid(input)
         self.assertFalse(output)
 
-    def test_bioguide_id_valid_url__returns_False(self):
+    def test_bioguide_id_valid_url__returns_false(self):
         """ Test with an invalid ID, an URL """
         input = "http://young.house.gov"
         output = gpo_member_photos.bioguide_id_valid(input)


### PR DESCRIPTION
`test_resolve__none()` wasn't actually inputting None into `gpo_member_photos.resolve()`.
- Fix the test to input None -> the test fails.
- Fix the code so the test passes.
- flake8.
