### PR TITLE
Add third parameter: issue number

### DIFF
--- a/scripts/update_image.sh
+++ b/scripts/update_image.sh
@@ -1,11 +1,12 @@
-# Usage: scripts/update_image.sh url bioguide_id
-# Example: scripts/update_image.sh https://cloud.githubusercontent.com/assets/3171982/7097441/ab606912-dfa3-11e4-8e1f-bb7c944fe877.jpg Y000066
+# Usage: scripts/update_image.sh url bioguide_id issue_number
+# Example: scripts/update_image.sh https://cloud.githubusercontent.com/assets/3171982/7505422/46c2791e-f420-11e4-9360-0bb6ff136a04.jpg T000476 85
 
 # Download an original image, delete and create new thumbnails,
 # open its metadata file for editing, do some git things.
 
 echo "URL:" $1
 echo "Bioguide ID:" $2
+echo "Issue number:" $3
 edit congress/metadata/$2.yaml
 wget $1 -O congress/original/$2.jpg
 rm congress/225x275/$2.jpg
@@ -14,4 +15,4 @@ scripts/resize-photos.sh
 git status
 git add congress
 git status
-echo git commit -m \"Update $2 via \#
+echo git commit -m \"Update $2 via \#$3\"


### PR DESCRIPTION
Usage: 
`scripts/update_image.sh url bioguide_id issue_number`

Example: 
`scripts/update_image.sh https://cloud.githubusercontent.com/assets/3171982/7505422/46c2791e-f420-11e4-9360-0bb6ff136a04.jpg T000476 85`

So it also echoes the full git commit command, ready for copy and pasting, for example:
`git commit -m "Update T000476 via #85`

Doesn't actually call it, in case the update didn't work.
