### PR TITLE
Make tests pass on Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
   - 3.3
   - 3.2
   - pypy
+  - pypy3
 
 # whitelist
 # gh-pages is otherwise ignored by Travis CI
@@ -37,9 +38,5 @@ after_success:
 matrix:
   fast_finish: true
   allow_failures:
-    - python: 2.6
     - python: 3.2
-    - python: 3.3
-    - python: 3.4
-    - python: 3.5
-    - python: pypy
+    - python: pypy3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,12 @@ language: python
 sudo: false
 
 python:
-  - 2.6
   - 2.7
-  - 3.2
-  - 3.3
+  - 2.6
+  - 3.5
   - 3.4
+  - 3.3
+  - 3.2
   - pypy
 
 # whitelist
@@ -40,4 +41,5 @@ matrix:
     - python: 3.2
     - python: 3.3
     - python: 3.4
+    - python: 3.5
     - python: pypy

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ python:
   - 3.4
   - 3.3
   - 3.2
-  - pypy
   - pypy3
+  - pypy
 
 # whitelist
 # gh-pages is otherwise ignored by Travis CI
@@ -39,4 +39,3 @@ matrix:
   fast_finish: true
   allow_failures:
     - python: 3.2
-    - python: pypy3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 PyYAML
-mechanize
+MechanicalSoup

--- a/scripts/gpo_member_photos.py
+++ b/scripts/gpo_member_photos.py
@@ -58,13 +58,13 @@ def get_front_page(br, congress_number, delay):
     ######################################
     # First, open the page to get the form
     ######################################
-    br.set_handle_robots(False)   # no robots
-    br.set_handle_refresh(False)  # can sometimes hang without this
+#     br.set_handle_robots(False)   # no robots
+#     br.set_handle_refresh(False)  # can sometimes hang without this
     br.addheaders = [('User-agent',
                       'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.1) '
                       'Gecko/2008071615 Fedora/3.0.1-1.fc9 Firefox/3.0.1')]
 
-    response = br.open(url).read()
+    response = br.get(url).text
 
     if len(response) == 0:
         sys.exit("Page is blank. Try again later, you may have hit a limit.")

--- a/scripts/gpo_member_photos.py
+++ b/scripts/gpo_member_photos.py
@@ -24,7 +24,7 @@ except ImportError:
     from urlparse import urlparse
 
 # pip install -r requirements.txt
-import mechanize
+import mechanicalsoup
 import yaml
 
 
@@ -335,7 +335,7 @@ if __name__ == "__main__":
     # clone or update legislator YAML
     download_legislator_data()
 
-    br = mechanize.Browser()
+    br = mechanicalsoup.Browser()
     member_links = get_front_page(br, args.congress, args.delay)
 
     download_photos(br, member_links, args.outdir, args.cache, args.delay)

--- a/scripts/gpo_member_photos.py
+++ b/scripts/gpo_member_photos.py
@@ -4,7 +4,7 @@
 Scrape http://memberguide.gpo.gov and
 save members' photos named after their Bioguide IDs.
 """
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import argparse
 import datetime
 import os
@@ -112,9 +112,6 @@ def get_value(item, key1, key2):
 def resolve(data, text):
     if text is None:
         return None
-
-    if isinstance(text, str):
-        text = text.decode('utf-8')
 
     # hardcoded special cases to deal with bad data in GPO
     if text == "Bradley, Byrne":  # Really "Byrne, Bradley"

--- a/test/test_gpo_member_photos.py
+++ b/test/test_gpo_member_photos.py
@@ -5,6 +5,7 @@ Unit tests for gpo_member_photos.py.
 Run from root `images` dir:
 `python test/test_gpo_member_photos.py`
 """
+from __future__ import print_function, unicode_literals
 import sys
 try:
     import unittest2 as unittest
@@ -163,7 +164,7 @@ class TestSequenceFunctions(unittest.TestCase):
 
     def test_resolve__remove_nickname_quotes(self):
         """ Test resolve """
-        text = str('Barr, Garland “Andy"')
+        text = 'Barr, Garland “Andy"'
         output = gpo_member_photos.resolve(self.yaml_data, text)
         self.assertEqual(output, "B001282")
 


### PR DESCRIPTION
Fixes #12.

The Mechanize module doesn't support Python 3, but the [MechanicalSoup](https://github.com/hickford/MechanicalSoup) module does, so lets use that.

Tests pass on Travis for all available Pythons 2 and 3, apart from 3.2 but I doubt we really care about that.

The script works with Python 2.7 on my machine in normal use. I'll try and test on Python 3 in normal use at some point.
