### PR TITLE
Explicitly whitelist gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ python:
 # Use a regex to whitelist gh-pages and all branches
 branches:
   only:
+    - gh-pages
     - /.*/
 
 install:


### PR DESCRIPTION
Travis CI must have changed their defaults since https://github.com/unitedstates/images/pull/34, as the gh-pages is not being built, only other branches.

https://docs.travis-ci.com/user/customizing-the-build/#Safelisting-or-blocklisting-branches now says:

> By default, the `gh-pages` branch is not built unless you add it to the safelist.
> To have _all_ branches build:

```yml
branches:
  only:
    - gh-pages
    - /.*/
```

Yes, tell Travis to build only anything, but also gh-pages.