### PR TITLE
Update coverage command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ install:
   - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then travis_retry pip install unittest2; fi
 
 script:
-  - coverage run --source scripts/gpo_member_photos.py test/test_gpo_member_photos.py
-  - python scripts/missing.py
+  - coverage run  --append --source scripts test/test_gpo_member_photos.py
+  - coverage run  --append --source scripts scripts/missing.py
 
 after_success:
   - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,10 @@ sudo: false
 
 python:
   - 2.7
-  - 2.6
   - 3.6
   - 3.5
   - 3.4
   - 3.3
-  - 3.2
   - pypy3
   - pypy
 
@@ -39,6 +37,3 @@ after_success:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - python: 2.6
-    - python: 3.2


### PR DESCRIPTION
The `--source` parameter changed in Coverage 3.3 to take a package or directory, so update how it's called and cover running missing.py as well.

Also remove Python 2.6 and 3.2, they were failing and are no longer supported anyway: https://en.wikipedia.org/wiki/CPython#Version_history