### PR TITLE
Fix ssl.CertificateError: hostname 'www.memberguide.gpo.gov' doesn't match 'memberguide.gpo.gov'

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you want to quickly grab all images of a particular size without cloning the 
 [![Build Status](https://travis-ci.org/unitedstates/images.svg?branch=gh-pages)](https://travis-ci.org/unitedstates/images)
 [![Coverage Status](https://coveralls.io/repos/unitedstates/images/badge.svg?branch=gh-pages&service=github)](https://coveralls.io/github/unitedstates/images?branch=gh-pages)
 
-This project uses a Python script that scrapes the [Government Printing Office's Member Guide](http://memberguide.gpo.gov/) for official photos of Members of Congress. You can run the script to find and fetch new photos.
+This project uses a Python script that scrapes the [Government Printing Office's Member Guide](https://memberguide.gpo.gov/) for official photos of Members of Congress. You can run the script to find and fetch new photos.
 
 Install dependencies with:
 

--- a/scripts/gpo_member_photos.py
+++ b/scripts/gpo_member_photos.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Scrape http://memberguide.gpo.gov and
+Scrape https://memberguide.gpo.gov and
 save members' photos named after their Bioguide IDs.
 """
 from __future__ import print_function, unicode_literals
@@ -101,7 +101,7 @@ def save_metadata(bioguide_id):
     outfile = os.path.join(outdir, bioguide_id + ".yaml")
     with open(outfile, "w") as f:
         f.write("name: GPO Member Guide\n")
-        f.write("link: http://memberguide.gpo.gov\n")
+        f.write("link: https://memberguide.gpo.gov\n")
 
 
 def download_file(url, outfile):
@@ -125,7 +125,7 @@ def download_photos(br, photo_list, outdir, delay):
     ok = 0
 
     for bioguide_id, photo_filename in photo_list:
-        photo_url = ("http://www.memberguide.gpo.gov/PictorialImages/" +
+        photo_url = ("https://memberguide.gpo.gov/PictorialImages/" +
                      photo_filename)
         print(bioguide_id, photo_url)
 
@@ -153,7 +153,7 @@ def resize_photos():
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Scrape http://memberguide.gpo.gov and save "
+        description="Scrape https://memberguide.gpo.gov and save "
                     "members' photos named after their Bioguide IDs",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(


### PR DESCRIPTION
* [x] *I'm acknowledging that my submission is free of all known copyright in at least the United States.* (In general, works of the federal government should satisfy this criteria.)

Link is now https://memberguide.gpo.gov not http://www.memberguide.gpo.gov.