### PR TITLE
Add Zenodo DOI badge to make repo citable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Images of Congress
 
+[![DOI](https://zenodo.org/badge/16810726.svg)](https://zenodo.org/badge/latestdoi/16810726)
+
 Public domain images of members of the US Congress.
 
 ## Using the photos


### PR DESCRIPTION
* [x] *I'm acknowledging that my submission is free of all known copyright in at least the United States.* (In general, works of the federal government should satisfy this criteria.)

It might be useful for some people to be able to cite this repo:

* https://doi.org/10.5281/zenodo.3723105

I created a [CalVer](https://calver.org/) `YYYY.0M` 2020.03 release to enable this. Just one is needed to show up there, we can easily make new releases in the future if needed.