### PR TITLE
fix(gpo_member_photos): regex was returning 0 results

### DIFF
--- a/scripts/gpo_member_photos.py
+++ b/scripts/gpo_member_photos.py
@@ -23,7 +23,7 @@ USER_AGENT = (
 )
 
 regex1 = re.compile(
-    r'<a href="https://www.congress.gov/member/[^/]+/(\w+)[^<]+</a></span>'
+    r'<a href="/member/[^/]+/(\w+)[^<]+</a></span>'
     '[^<]*<div[^<]+<div class="member-image"><img src="/img/member/([^"]+)"'
 )
 


### PR DESCRIPTION
## Summary

This PR fixes the script in `scripts/gpo_member_photos.py`. Before this PR 0 images would be found when scanning pages for image URLs. 

This PR updates the image regex so that it searches the HTML for `<a href="/member/[^/]+/(\w+)[^<]+</a></span>`.

_Old value: `<a href="https://www.congress.gov/member/[^/]+/(\w+)[^<]+</a></span>`_

- [x] _I'm acknowledging that my submission is free of all known copyright in at least
      the United States._ (In general, works of the federal government should satisfy
      this criteria.)
